### PR TITLE
Update itu-ob-data

### DIFF
--- a/_plugins/issue_data_reader.rb
+++ b/_plugins/issue_data_reader.rb
@@ -20,7 +20,7 @@ module Jekyll
     def read_recommendations
       self.data['recommendations'] = {}
 
-      self.get_recommendations().each do |rec_path|
+      self.get_recommendations.each do |rec_path|
         rec_data = {
           'meta' => self.load_data('meta.yaml', rec_path),
         }
@@ -32,7 +32,7 @@ module Jekyll
     def read_publications
       self.data['publications'] = {}
 
-      self.get_publications().each do |pub_path|
+      self.get_publications.each do |pub_path|
         pub_data = {
           'meta' => self.load_data('meta.yaml', pub_path),
         }
@@ -56,7 +56,7 @@ module Jekyll
       issues_seq_asc = []
 
       # Read issues from filesystem, in unspecified order
-      self.get_issues().each do |issue_path|
+      self.get_issues.each do |issue_path|
         issue_data = {
           'meta' => self.load_data('meta.yaml', issue_path),
           'general' => self.load_data('general.yaml', issue_path, optional: true),
@@ -121,9 +121,9 @@ module Jekyll
       end
 
       # Obtain an array of complete (non-draft) issues, latest first
-      issues_seq_desc = issues_seq_asc.select {
-        |i_id| self.data['issues'][i_id]['meta']['publication_date'] < Date.today
-      }.reverse()
+      issues_seq_desc = issues_seq_asc.select do |i_id|
+        self.data['issues'][i_id]['meta']['publication_date'] < Date.today
+      end.reverse
 
       self.data['latest_issue_id'] = issues_seq_desc[0]
       self.data['previous_issue_id'] = issues_seq_desc[1]


### PR DESCRIPTION
There is this following error in compilation:

```
"ERROR: Failed to fetch recommendation title for G.9964 (2011) Amd. 3  2/20"
"ERROR: Failed to fetch recommendation title for T Q.5051  3/20"
"ERROR: L10N: trans_file passed empty string or object in issue 1117, include.contents"
"ERROR: L10N: trans_file passed empty string or object in issue 1117, include.contents"
"ERROR: L10N: trans_file passed empty string or object in issue 1117, include.contents"
bundler: failed to load command: jekyll (/Users/me/.rbenv/versions/2.6.5/bin/jekyll)
Errno::EEXIST: File exists @ dir_s_mkdir - /Users/me/src/ituob/ituob.org/_site/_app_help/index.html
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:239:in `mkdir'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:239:in `fu_mkdir'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:217:in `block (2 levels) in mkdir_p'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:215:in `reverse_each'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:215:in `block in mkdir_p'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:200:in `each'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/2.6.0/fileutils.rb:200:in `mkdir_p'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/convertible.rb:226:in `write'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:209:in `block in write'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:332:in `block (2 levels) in each_site_file'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:331:in `each'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:331:in `block in each_site_file'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:330:in `each'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:330:in `each_site_file'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:208:in `write'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/site.rb:73:in `process'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/command.rb:28:in `process_site'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/commands/build.rb:65:in `build'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/commands/build.rb:36:in `process'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/lib/jekyll/commands/build.rb:18:in `block (2 levels) in init_with_program'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
  /Users/me/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/jekyll-3.8.7/exe/jekyll:15:in `<top (required)>'
  /Users/me/.rbenv/versions/2.6.5/bin/jekyll:23:in `load'
  /Users/me/.rbenv/versions/2.6.5/bin/jekyll:23:in `<top (required)>'
make: *** [_site] Error 1

```

Not sure where it is re-generating this app_help page?